### PR TITLE
Add FastAPI root endpoint

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,8 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.get("/")
+async def read_root():
+    return {"message": "hey i am using codex"}


### PR DESCRIPTION
## Summary
- add minimal FastAPI app with root endpoint returning a greeting

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb0bcf36d883328f22ed46b5978f1c