### PR TITLE
Configure FastAPI app for Vercel deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # pycodex
+
+Simple FastAPI API.
+
+## Development
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+Run locally:
+
+```bash
+uvicorn main:app --reload
+```
+
+## Deployment
+
+This project is configured for deployment on Vercel using `vercel.json`, which routes all requests to `main.py`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "version": 2,
+  "builds": [
+    {"src": "main.py", "use": "@vercel/python"}
+  ],
+  "routes": [
+    {"src": "/(.*)", "dest": "main.py"}
+  ]
+}


### PR DESCRIPTION
## Summary
- add `vercel.json` config to deploy FastAPI on Vercel
- document development and deployment steps
- declare FastAPI and Uvicorn dependencies

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb0cdd07b08332b71573f9aa9652f2